### PR TITLE
Fix MySQL FK name length limit and add PostgreSQL Exists() regression test

### DIFF
--- a/Tests/FAnsiTests/Database/DatabaseExistsTests.cs
+++ b/Tests/FAnsiTests/Database/DatabaseExistsTests.cs
@@ -1,0 +1,75 @@
+using FAnsi;
+using FAnsi.Discovery;
+using NUnit.Framework;
+
+namespace FAnsiTests.Database;
+
+/// <summary>
+/// Tests for DiscoveredDatabase.Exists() method across all database types.
+/// Verifies that checking for non-existent databases returns false instead of throwing exceptions.
+/// </summary>
+internal sealed class DatabaseExistsTests : DatabaseTests
+{
+    /// <summary>
+    /// Test that DiscoveredDatabase.Exists() returns false for non-existent databases
+    /// without throwing exceptions. This is critical for PostgreSQL where connecting
+    /// to a non-existent database throws an exception.
+    /// </summary>
+    /// <remarks>
+    /// Upstream issue: HicServices/FAnsiSql#335
+    /// PostgreSQL requires connecting to a system database (postgres) first to query pg_database.
+    /// This fork's implementation correctly handles this by using DatabaseExists() which connects
+    /// to the postgres system database before checking.
+    /// </remarks>
+    [TestCaseSource(typeof(All), nameof(All.DatabaseTypes))]
+    public void DiscoveredDatabase_Exists_NonExistentDatabase_ReturnsFalse(DatabaseType dbType)
+    {
+        var server = GetTestServer(dbType);
+        var db = server.ExpectDatabase("NonExistentDatabase_12345");
+
+        // Should return false, not throw an exception
+        Assert.That(db.Exists(), Is.False,
+            $"Exists() should return false for non-existent database on {dbType}, not throw an exception");
+    }
+
+    /// <summary>
+    /// Test that DiscoveredDatabase.Exists() returns true for existing databases
+    /// </summary>
+    [TestCaseSource(typeof(All), nameof(All.DatabaseTypes))]
+    public void DiscoveredDatabase_Exists_ExistingDatabase_ReturnsTrue(DatabaseType dbType)
+    {
+        var db = GetTestDatabase(dbType);
+
+        Assert.That(db.Exists(), Is.True,
+            $"Exists() should return true for existing database on {dbType}");
+    }
+
+    /// <summary>
+    /// Test that creating and then checking a database works correctly
+    /// </summary>
+    [TestCaseSource(typeof(All), nameof(All.DatabaseTypes))]
+    public void DiscoveredDatabase_Exists_AfterCreate_ReturnsTrue(DatabaseType dbType)
+    {
+        var server = GetTestServer(dbType);
+        var dbName = $"TestExistsDB_{dbType}_{System.Guid.NewGuid():N}".Substring(0, 30);
+        var db = server.ExpectDatabase(dbName);
+
+        try
+        {
+            // Should not exist initially
+            Assert.That(db.Exists(), Is.False, "Database should not exist before creation");
+
+            // Create it
+            db.Create();
+
+            // Should exist now
+            Assert.That(db.Exists(), Is.True, "Database should exist after creation");
+        }
+        finally
+        {
+            // Clean up
+            if (db.Exists())
+                db.Drop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses two issues from the upstream HicServices/FAnsiSql repository:
- Fixes Issue HicServices/FAnsiSql#276 (MySQL FK name length limit)
- Adds regression tests for Issue HicServices/FAnsiSql#335 (already fixed in this fork)

## Issue #276: MySQL FK Name Length Limit

**Problem:** Auto-generated foreign key names like `FK_ForeignKeyCreationTest_TwoColumnsC_ForeignKeyCreationTest_TwoColumnsP` (73 chars) exceed MySQL's 64-character identifier limit, causing:
```
MySqlException: Identifier name 'FK_...' is too long
```

**Solution:**
- Added constraint name truncation with deterministic hashing
- Format: `FK_{truncated}_{8-hex-hash}`
- Hash ensures uniqueness while keeping total length ≤ 64 characters
- Example: `FK_ForeignKeyCreationTest_TwoColumnsC_ForeignKey_A1B2C3D4`
- Deterministic: same input always produces same hash

**Code changes:**
- Updated `MakeSensibleConstraintName()` in DiscoveredDatabaseHelper.cs
- Added `GetDeterministicHash()` helper method
- Applies to both FK and PK constraint names

## Issue #335: PostgreSQL Exists() Exception (Already Fixed)

**Problem (upstream):** `DiscoveredDatabase.Exists()` throws exception for PostgreSQL instead of returning `false` when checking non-existent databases.

**Status in this fork:** ✅ **Already fixed!**

The PostgreSQL implementation correctly:
1. Connects to the `postgres` system database
2. Queries `pg_database` catalog
3. Returns `false` if database doesn't exist (no exception)

**Verification:** Added comprehensive test suite:
- `DatabaseExistsTests.cs` with 3 test cases × 5 database types
- Tests non-existent database returns `false`
- Tests existing database returns `true`
- Tests create-then-check workflow

## Files Changed

- `FAnsi.Core/Discovery/DiscoveredDatabaseHelper.cs` (+42, -4)
- `Tests/FAnsiTests/Database/DatabaseExistsTests.cs` (new, +75 lines)

## Testing

Local build: ✅ 0 warnings, 0 errors
Database tests: Will run in CI (requires DB servers)

## Breaking Changes

None