### PR TITLE
Remove obsolete ReflectionTypeLoadException handling

### DIFF
--- a/FAnsi.MicrosoftSql/MicrosoftSQLBulkCopy.cs
+++ b/FAnsi.MicrosoftSql/MicrosoftSQLBulkCopy.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using FAnsi.Connections;
@@ -286,13 +285,6 @@ public sealed partial class MicrosoftSQLBulkCopy : BulkCopy
             message.AppendLine();
             message.Append(e.StackTrace);
         }
-
-        if (e is ReflectionTypeLoadException reflectionTypeLoadException)
-            foreach (var loaderException in reflectionTypeLoadException.LoaderExceptions.OfType<Exception>())
-            {
-                message.AppendLine();
-                message.Append(ExceptionToListOfInnerMessages(loaderException, includeStackTrace));
-            }
 
         if (e.InnerException == null) return message.ToString();
 


### PR DESCRIPTION
## Summary

Removes obsolete `ReflectionTypeLoadException` handling from `MicrosoftSQLBulkCopy.cs` that is no longer needed after the v3.5.0 architecture simplification.

## Background

In FAnsiSql v3.5.0 (#51), we eliminated reflection-based assembly loading in favor of direct `Type.GetType()` calls and `ModuleInitializer` patterns. This makes the code AOT-compatible and removes the possibility of `ReflectionTypeLoadException`.

## Changes

- Remove unused `using System.Reflection;` directive
- Remove `ReflectionTypeLoadException` handling in `ExceptionToListOfInnerMessages()` method
- This handling code was added for the old reflection-based loading pattern that no longer exists

## Impact

- No functional change - this exception path is now unreachable
- Cleaner code with no dead error handling paths
- Reduces confusion about when/why reflection exceptions might occur

## Files Changed

- `FAnsi.MicrosoftSql/MicrosoftSQLBulkCopy.cs` - Remove 8 lines of obsolete code

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes obsolete reflection-related exception handling code from the Microsoft SQL bulk copy implementation. Following the v3.5.0 architecture simplification that eliminated reflection-based assembly loading in favor of direct `Type.GetType()` calls, the `ReflectionTypeLoadException` handling is no longer needed and has been removed along with the unused `System.Reflection` import.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `FAnsi.MicrosoftSql/MicrosoftSQLBulkCopy.cs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->