### PR TITLE
fix(tests): replace obsolete NUnit TestDelegate with Action

### DIFF
--- a/tests/FAnsiTests/Table/BulkCopyTestsBase.cs
+++ b/tests/FAnsiTests/Table/BulkCopyTestsBase.cs
@@ -28,7 +28,7 @@ internal abstract class BulkCopyTestsBase : DatabaseTests
     ///     - SQL Server: InvalidOperationException or FileLoadException
     ///     Note: SQLite doesn't enforce some constraints (e.g., string length, integer overflow) so may not throw.
     /// </summary>
-    private static void AssertThrowsException(DatabaseType type, TestDelegate code, string? messageContains = null,
+    private static void AssertThrowsException(DatabaseType type, Action code, string? messageContains = null,
         bool sqliteMayNotThrow = false)
     {
         if (type == DatabaseType.Sqlite && sqliteMayNotThrow)


### PR DESCRIPTION
## Summary

NUnit's \`TestDelegate\` is marked obsolete (\"Use Action instead of TestDelegate\"). Replacing the parameter type in \`AssertThrowsException\` also makes the \`Assert.Catch\` call resolve to the non-obsolete \`Action\` overload, so both CS0618 warnings disappear.

## Why

The two CS0618 warnings in \`tests/FAnsiTests/Table/BulkCopyTestsBase.cs\` are currently breaking the \`dotnet-format\` pre-commit hook on \`main\`, forcing contributors to \`--no-verify\`.

## Verification

- \`dotnet build tests/FAnsiTests -c Release\` → warning count drops 15 → 13 (both CS0618s gone), 0 errors.
- Pre-commit hooks pass.

## Test plan

- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced obsolete NUnit TestDelegate with Action in tests to remove CS0618 warnings and unblock the `dotnet-format` pre-commit hook. Updated AssertThrowsException so Assert.Catch resolves to the non-obsolete overload.

<sup>Written for commit 8635f4b5827084dca0b707409f8021c9e8c3dec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jas88/FAnsiSql/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

